### PR TITLE
Fixed issue that occurs with floating point calculations that causes wrap to overflow

### DIFF
--- a/lib/src/div.dart
+++ b/lib/src/div.dart
@@ -46,14 +46,20 @@ class Div extends StatelessWidget {
         final double singleBox = box.maxWidth / 12;
         final double childWidth = singleBox * col;
         final double childOffset = singleBox * offset;
+        final double otherWidths = (12 - col) * singleBox;
+        final double recalculatedChildWidth =
+            (childWidth + otherWidths) > box.maxWidth
+                ? childWidth - ((childWidth + otherWidths) - box.maxWidth)
+                : childWidth;
+
         return SizedBox(
-          width: childWidth + childOffset,
+          width: recalculatedChildWidth + childOffset,
           child: Row(
             mainAxisSize: MainAxisSize.max,
             mainAxisAlignment: MainAxisAlignment.end,
             children: <Widget>[
               SizedBox(
-                width: childWidth,
+                width: recalculatedChildWidth,
                 child: child,
               ),
             ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: responsive_ui
 description: responsive ui Flutter package helps you to create a responsive and Nested responsive widget. Works on android, iOs, Web with both portrait and landscape mode.
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/bharathraj-e/responsive_ui
 
 environment:


### PR DESCRIPTION
Addresses issue identified [here](https://github.com/bharathraj-e/responsive_ui/issues/5)

I've opted out from writing comments in the code changes to keep in line with the current structure. I'll explain the changes here instead. 

[this line](https://github.com/bharathraj-e/responsive_ui/compare/master...Chappie74:responsive_ui:calculation_fixes?expand=1#diff-843fda16a3fddfffc1290ed2313058de116e55c5b21c39f6f92a9e97eb12d66aR49) calculates the total width of all other boxes present (minus the current one).

 [this line](https://github.com/bharathraj-e/responsive_ui/compare/master...Chappie74:responsive_ui:calculation_fixes?expand=1#diff-843fda16a3fddfffc1290ed2313058de116e55c5b21c39f6f92a9e97eb12d66aR50) then checks to see if the total widths of all the boxes is greater than the maximum allowable width (constraints.maxWidth). 
 If in some cases (as pointed out by the issue) this is true, then the `childWidth` is recalculated by subtracting the extra amount. 
 
 <img src="https://i.imgur.com/xEaBZsP.gif" width="500"/>